### PR TITLE
Using first RooUnfold in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Build with `cmake`, using
     make -j4
     cd ..
     source build/setup.sh
+    
+Please make sure that you source the setup.sh script before using this class. The RooUnfoldOmnifold class looks for a RooUnfold installation in the PATH variables and will use choose the installation that is most recently sourced. 
 
 Usage
 ---
@@ -54,6 +56,12 @@ The jet data can be obtained using the [preprocess_omnifold.py script from the O
 
 The PET and DNN models can be installed from the [PyPI omnifold module](https://pypi.org/project/omnifold/) using `pip install omnifold`.
 
+Common issues
+---
+1. `AttributeError: Failed to get attribute RooUnfoldOmnifold from ROOT`
+   
+   This likely means that the RooUnfold being used isn't the one installed from this repository. This typically happens if a different RooUnfold version's setup.sh script is used before using the RooUnfoldOmnifold class. To fix this, please source the setup.sh associated with this repository again.
+   
 Bugs/Issues
 ---
 

--- a/src/RooUnfoldOmnifold.cxx
+++ b/src/RooUnfoldOmnifold.cxx
@@ -121,15 +121,13 @@ RooUnfoldOmnifoldT<Hist,Hist2D>::Init()
   TString RooUnfold_install_path;
   for(auto &path : dynamic_paths)
   {
+    // Looking for RooUnfold installations in the path
+    // Uses the first installation found
     TString RooUnfold_library_name = "libRooUnfold.so";
     if(gSystem->FindFile(path.c_str(), RooUnfold_library_name))
     {
-      if(!RooUnfold_install_path.IsNull())
-      {
-        std::cerr<<"WARNING: Multiple RooUnfold installations detected in PATH"<<"\n"
-        "Previously found "<<RooUnfold_install_path<<". Will now use "<<path<<" for OmniFold."<<std::endl;
-      }
       RooUnfold_install_path = path;
+      break;
     }
   }
   TString omnifold_path;


### PR DESCRIPTION
Addresses Issue #1. This makes the RooUnfoldOmnifold class use the first RooUnfold in the PATH to search for omnifold.py. This makes it more intuitive for users since the most recently sourced RooUnfold file.