### PR TITLE
Replace TPython::Eval with TPython::Exec for ROOT >=6.34 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains the RooUnfoldOmnifold class that is an implementation o
 - [ROOT](https://root.cern/install/) (>= 6.10). This code has been tested with ROOT 6.32-6.36.
 - [scikit-learn](https://scikit-learn.org/stable/install.html) (`pip install scikit-learn`)
 - NumPy (`pip install numpy`)
+  
 Building the library
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ OmniFold Boosted Decision Tree implementation in RooUnfold
 This repository contains the RooUnfoldOmnifold class that is an implementation of Omnifold using boosted decision trees (BDTs) within a fork of the RooUnfold framework. RooUnfold itself and associated details can be found in its [GitLab repository](https://gitlab.cern.ch/RooUnfold/RooUnfold). Thank you to Lydia Brenner and Vincent Croft of the RooUnfold team for providing guidance with making this implementation.
 
 
+### Prerequisites
+- [ROOT](https://root.cern/install/) (>= 6.10). This code has been tested with ROOT 6.32-6.36.
+- [scikit-learn](https://scikit-learn.org/stable/install.html) (`pip install scikit-learn`)
+- NumPy (`pip install numpy`)
 Building the library
 ---
 


### PR DESCRIPTION
TPython::Eval became deprecated in ROOT 6.34 and was removed in 6.36. The functionality was replaced by TPython::Exec combined with std::any. The TPython::Exec approach does not work before ROOT 6.34, so TPython::Eval functionality was maintained for ROOT <6.34.

Addresses Issue #3.