### PR TITLE
Fixing get_step1_predictions() when pass_reco isn't provided

### DIFF
--- a/python/omnifold.py
+++ b/python/omnifold.py
@@ -284,6 +284,8 @@ class OmniFold_helper_functions:
         with open(file, "rb") as infile:
             loaded_models = pickle.load(infile)
         step1_test_weights = np.ones(len(MCreco_data))
+        if pass_reco is None or len(pass_reco)==0:
+            pass_reco = np.full_like(step1_test_weights, True, dtype=bool)
         step1_test_weights[pass_reco] = OmniFold_helper_functions.reweight(MCreco_data[pass_reco], loaded_models['step1_classifier'])
         if any(~pass_reco):
             step1_test_weights[~pass_reco] = loaded_models['step1_regressor'].predict(MCgen_data[~pass_reco])


### PR DESCRIPTION
When pass_reco isn't provided to `get_step1_predictions()`, there's an error since it's trying to mask an array with None. This occurs when the user doesn't call `SetTestMCPassReco()` before `TestUnbinnedOmnifold()`, which isn't required.

Made pass_reco all true if it's None or empty to fix this.